### PR TITLE
Fix to have mixin before class inheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ from wagtailorderable.modeladmin.mixins import OrderableMixin
 from .models import YourModel
 
 
-class YourModelAdmin(ModelAdmin, OrderableMixin):
+class YourModelAdmin(OrderableMixin, ModelAdmin):
     model = YourModel
     
     ordering = ['sort_order']


### PR DESCRIPTION
The mixin should come first as the class hierarachy is defined from right to
left.

Reference: https://www.ianlewis.org/en/mixins-and-python
