### PR TITLE
Handle list_display with tuple syntax

### DIFF
--- a/wagtailorderable/modeladmin/mixins.py
+++ b/wagtailorderable/modeladmin/mixins.py
@@ -31,6 +31,8 @@ class OrderableMixin(object):
         """Add `index_order` as the first column to results"""
         list_display = super(OrderableMixin, self).get_list_display(request)
         order_col_prepend = ['index_order']
+        if isinstance(list_display, tuple):
+            order_col_prepend = tuple(order_col_prepend)
         return order_col_prepend + list_display
 
     def get_list_display_add_buttons(self, request):


### PR DESCRIPTION
This PR intends to make wagtail-orderable compatible with the tuple syntax for ModelAdmin attributes.

```
class MyModelAdmin(OrderableMixin, ModelAdmin):
    ...
    list_display = ('field1', 'field2')
    ordering = ('sort_order',)
```

Tested on the project I'm working on (Django 2.1.7).