### PR TITLE
Handle any iterable in get_list_display

### DIFF
--- a/wagtailorderable/modeladmin/mixins.py
+++ b/wagtailorderable/modeladmin/mixins.py
@@ -29,9 +29,8 @@ class OrderableMixin(object):
 
     def get_list_display(self, request):
         """Add `index_order` as the first column to results"""
-        list_display = super(OrderableMixin, self).get_list_display(request)
-        order_col_prepend = ['index_order']
-        return order_col_prepend + list_display
+        list_display = super().get_list_display(request)
+        return = ('index_order', *list_display)
 
     def get_list_display_add_buttons(self, request):
         """


### PR DESCRIPTION
`get_list_display()` can return a list or a tuple (or any iterable for that matter). Don't assume it is always a list.

Also, Wagtail only supports Python 3, so use Python 3 niceties such as `super()` without arguments.

Fixes #10 