### PR TITLE
Update to support list filters

### DIFF
--- a/wagtailorderable/modeladmin/mixins.py
+++ b/wagtailorderable/modeladmin/mixins.py
@@ -108,7 +108,7 @@ class OrderableMixin(object):
             position = after_position
             response = HttpResponse('"%s" was moved after "%s"' % (obj_to_move, after))
         elif before_position:
-            position = before_position - 1
+            position = before_position
             response = HttpResponse('"%s" was moved before "%s"' % (obj_to_move, before))
         else:
             position = 0

--- a/wagtailorderable/static/wagtailorderable/modeladmin/js/orderablemixin.js
+++ b/wagtailorderable/static/wagtailorderable/modeladmin/js/orderablemixin.js
@@ -15,8 +15,9 @@ $(function() {
             items: "> tr",
             axis: "y",
             placeholder: "dropzone",
-            start: function(){
+            start: function(event, ui){
                 $(this).parent().addClass('sorting');
+                $(this).data('idx', ui.item.index());
             },
             stop: function(event, ui){
                 $(this).parent().removeClass('sorting');
@@ -25,15 +26,28 @@ $(function() {
                 var movedElement = $(ui.item[0]);
                 var movedObjectId = movedElement.data('object-pk');
                 var movedObjectTitle = movedElement.find('td.field-index_order').data('title');
-                var newPosition = $(movedElement).prevAll().length + 1;
 
-                // Build url
-                var url = "reorder/" + movedObjectId + "/?position=" + newPosition;
+                // Build params
+                var params;
+                if ($(this).data('idx') < ui.item.index()) {
+                    var after = $(movedElement).prev().data('object-pk');
+                    if (after) {
+                        params= "?after=" + after;
+                    }
+                } else if ($(this).data('idx') > ui.item.index()){
+                    var before = $(movedElement).next().data('object-pk');
+                    if (before) {
+                        params = "?before=" + before;
+                    }
+                }
 
                 // Post
-                $.get(url, function(){
-                    addMessage('success', '"' + movedObjectTitle + '" has been moved successfully.');
-                });
+                if (params) {
+                    var url = "reorder/" + movedObjectId + '/' + params;
+                    $.get(url, function(){
+                        addMessage('success', '"' + movedObjectTitle + '" has been moved successfully.');
+                    });
+                }
             }
         });
         listing_tbody.disableSelection();


### PR DESCRIPTION
Update to support ModelAdmin filters.  This is done by passing which object to move before (when moving up the list) or after (when moving down the list) instead of an absolute position in whatever was rendered.