### PR TITLE
Fix wrong return syntax

### DIFF
--- a/wagtailorderable/modeladmin/mixins.py
+++ b/wagtailorderable/modeladmin/mixins.py
@@ -30,7 +30,7 @@ class OrderableMixin(object):
     def get_list_display(self, request):
         """Add `index_order` as the first column to results"""
         list_display = super().get_list_display(request)
-        return = ('index_order', *list_display)
+        return ('index_order', *list_display)
 
     def get_list_display_add_buttons(self, request):
         """


### PR DESCRIPTION
This PR fixes a SyntaxError caused by `return =` at this line https://github.com/elton2048/wagtail-orderable/blob/1.0.1/wagtailorderable/modeladmin/mixins.py#L33