### PR TITLE
Important fix for duplicates of the sort_order

### DIFF
--- a/wagtailorderable/models.py
+++ b/wagtailorderable/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.db.models import Max
 
 
 class Orderable(models.Model):
@@ -15,8 +16,8 @@ class Orderable(models.Model):
     sort_order_field = 'sort_order'
 
     def save(self, *args, **kwargs):
-        if self.pk == None:
-            self.sort_order = self.__class__.objects.count() + 1
+        if self.pk is None:
+            self.sort_order = self.__class__.objects.aggregate(Max('sort_order'))['sort_order__max'] + 1
         super().save(*args, **kwargs)
 
     class Meta:

--- a/wagtailorderable/static/wagtailorderable/modeladmin/js/orderablemixin.js
+++ b/wagtailorderable/static/wagtailorderable/modeladmin/js/orderablemixin.js
@@ -35,7 +35,7 @@ $(function() {
                     if (after) {
                         params= "?after=" + after;
                     }
-                } else if ($(this).data('idx') > ui.item.index()){
+                } else if ($(this).data('idx') > ui.item.index()) {
                     var before = $(movedElement).next().data('object-pk');
                     if (before) {
                         params = "?before=" + before;
@@ -44,9 +44,15 @@ $(function() {
 
                 // Post
                 if (params) {
-                    var url = "reorder/" + movedObjectId + '/' + params;
-                    $.get(url, function(){
-                        addMessage('success', '"' + movedObjectTitle + '" has been moved successfully.');
+                    $.ajax({
+                        url: 'reorder/' + movedObjectId + '/' + params,
+                        success: function(data, textStatus, xhr) {
+                            addMessage('success', '"' + movedObjectTitle + '" has been moved successfully.');
+                        },
+                        error: function(data, textStatus, xhr) {
+                            addMessage('error', '"' + movedObjectTitle + '" could not be moved.');
+                            listing_tbody.sortable("cancel");
+                        }
                     });
                 }
             }


### PR DESCRIPTION
- Added a function to remove duplicate (the sort order is re if duplicates are found)
- Fixed case that produced them (new items are added with MAX instead of COUNT, because deletes could cause gaps
- The UI now cancels the move and shows an error if the move command doesn't return 200.