### PR TITLE
Fix bug where first object can not be saved

### DIFF
--- a/wagtailorderable/models.py
+++ b/wagtailorderable/models.py
@@ -17,7 +17,8 @@ class Orderable(models.Model):
 
     def save(self, *args, **kwargs):
         if self.pk is None:
-            self.sort_order = self.__class__.objects.aggregate(Max('sort_order'))['sort_order__max'] + 1
+            sort_order_max = self.__class__.objects.aggregate(Max('sort_order'))['sort_order__max'] or 0
+            self.sort_order = sort_order_max + 1
         super().save(*args, **kwargs)
 
     class Meta:


### PR DESCRIPTION
This change implements the TypeError fix for when creating a first Orderable object instance 
errors - referenced in https://github.com/elton2048/wagtail-orderable/issues/21


