### PR TITLE
Fix small error in readme documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ from django.db import models
 from wagtailorderable.models import Orderable
 
 
-class YourModel(models.Model, Orderable):
+class YourModel(Orderable):
     title = models.CharField(max_length=200)
 ```
 


### PR DESCRIPTION
Hi there!

The `Orderable` model class already subclasses `models.Model`, so you'll get an MRO error if you try to subclass `models.Model` again as suggested in the readme example. This updates the example to fix this.