### PR TITLE
Wagtail 3.0 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   deploy:
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.7
     steps:
       - checkout
       - run:

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ python manage.py collectstatic
 in your project.
 
 ### Change Log
+## [Unreleased]
+- Add support for Wagtail 3.0 and drop support for all Wagtail versions
+   before 2.15
 1.0.3
 ---
 - Fix `TypeError` when creating the first Orderable object (#21)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 from setuptools.command.install import install
 
 INSTALL_REQUIRES = [
-    "wagtail>=2.0,<3.0",
+    "wagtail>=2.15,<4.0",
 ]
 
 CLASSIFIERS = [
@@ -16,13 +16,18 @@ CLASSIFIERS = [
     'Intended Audience :: Developers',
     'Operating System :: OS Independent',
     'Programming Language :: Python',
-    'Framework :: Django',
+    "Framework :: Django",
+    "Framework :: Django :: 3.2",
+    "Framework :: Django :: 4.0",
     'License :: OSI Approved :: zlib/libpng License',
-    'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.4',
-    'Programming Language :: Python :: 3.5',
-    'Programming Language :: Python :: 3.6',
-    'Framework :: Wagtail',
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Framework :: Wagtail",
+    "Framework :: Wagtail :: 2",
+    "Framework :: Wagtail :: 3",
 ]
 
 class VerifyVersionCommand(install):

--- a/wagtailorderable/modeladmin/mixins.py
+++ b/wagtailorderable/modeladmin/mixins.py
@@ -19,13 +19,13 @@ class OrderableMixin(object):
         super(OrderableMixin, self).__init__(parent)
         """
         Don't allow initialisation unless self.model subclasses
-        `wagtail.wagtailcore.models.Orderable`
+        `wagtail.models.Orderable`
         """
         if not issubclass(self.model, Orderable):
             raise ImproperlyConfigured(
                 u"You are using OrderableMixin for your '%s' class, but the "
                 "django model specified is not a sub-class of "
-                "'wagtail.wagtailcore.models.Orderable." %
+                "'wagtail.models.Orderable." %
                 self.__class__.__name__,)
 
     def get_list_display(self, request):

--- a/wagtailorderable/models.py
+++ b/wagtailorderable/models.py
@@ -6,7 +6,7 @@ class Orderable(models.Model):
     """
     Orderable class to add drag-and-drop ordering support to the ModelAdmin listing
     view. It is very similar to the Orderable class in
-    `wagtail.core.models.Orderable` excepts it saves the sort_order initially
+    `wagtail.models.Orderable` excepts it saves the sort_order initially
     if the object is new by checking whether the pk(Default Primary Key) field
     is None or not.
 


### PR DESCRIPTION
This package doesn't really depend on Wagtail that much, just lifting the instalment requirement should work.

I also upgrade the package to today's standard by removing EOF software versions. updating the CI image and package information. 