### PR TITLE
Use an unintrusive approach to avoid to inherit from Orderable (rebased)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,12 @@ INSTALLED_APPS = [
 
 ### Usage
 
-To apply the orderable feature, extend your model with `Orderable`.
+#### Extends with `Orderable` (optionnal)
+
+To apply the orderable feature, you can extend your model with `Orderable` which will add
+a `sort_order` `IntegerField` to your model but if you already have a field to store
+an index value, **this is not required**.
+
 ```python
 from django.db import models
 
@@ -46,6 +51,18 @@ class YourModel(Page, Orderable):
     description = fields.RichTextField(blank=True)
 ```
 
+
+Or just use your model with your personnal ordering field.
+
+```python
+from django.db import models
+
+
+class YourOtherModel(models.Model):
+    title = models.CharField(max_length=200)
+    my_custom_order_field = models.IntegerField(null=False, blank=True, default=0, editable=False)
+```
+
 Note that `Orderable` also exists in `wagtail.core.models`, **DO NOT** use that as the mixins require the model from the same package.
 
 To apply the feature support in admin panel. In `wagtail_hooks.py`:
@@ -55,16 +72,23 @@ from wagtail.contrib.modeladmin.options import (
 
 from wagtailorderable.modeladmin.mixins import OrderableMixin
 
-from .models import YourModel
+from .models import YourModel, YourOtherModel
 
 
 class YourModelAdmin(OrderableMixin, ModelAdmin):
     model = YourModel
 
-    ordering = ['sort_order']
+
+class YourOtherModelAdmin(OrderableMixin, ModelAdmin):
+    model = YourOtherModel
+    index_order_field = 'my_custom_order_field'
 
 modeladmin_register(YourModelAdmin)
+modeladmin_register(YourOtherModelAdmin)
 ```
+
+Note that `index_order_field` is optionnal if you extends your model with `Orderable`
+or if your Model has a `index_order_field` attribute.
 
 Finally, collect the corresponding static file by running
 ```python
@@ -73,12 +97,22 @@ python manage.py collectstatic
 in your project.
 
 ### Change Log
+
+[Unreleased]
+---
+- Extending `Orderable` is no more mandatory if you want to use your own order field (#27)
+- Add `Orderable.get_sort_order_max()` to get the max "order" when instance is being created (#27)
+- Fix keeping current filters when sorting was reset (#27)
+- Fix class names (`get_extra_class_names_for_field_col` parameters were inverted) (#27)
+- Fix CSS which had SCSS syntax (#27)
+
 1.0.4
 ---
 - Provide Github Actions script to build and publish package in PyPI
 - Add support for Wagtail 3.0 and drop support for all Wagtail versions
    before 2.15 (#32)
 - Use `pk` instead of `id` for duplicate positions (#31)
+
 1.0.3
 ---
 - Fix `TypeError` when creating the first Orderable object (#21)

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ class YourModel(Orderable):
 
 Of course you can apply it to Wagtail's `Page` model.
 ```python
-from wagtail.core import fields
-from wagtail.core.models import Page
+from wagtail import fields
+from wagtail.models import Page
 
 from wagtailorderable.models import Orderable
 
@@ -52,7 +52,7 @@ class YourModel(Page, Orderable):
 ```
 
 
-Or just use your model with your personnal ordering field.
+Or just use your model with your personal ordering field.
 
 ```python
 from django.db import models
@@ -63,7 +63,7 @@ class YourOtherModel(models.Model):
     my_custom_order_field = models.IntegerField(null=False, blank=True, default=0, editable=False)
 ```
 
-Note that `Orderable` also exists in `wagtail.core.models`, **DO NOT** use that as the mixins require the model from the same package.
+Note that `Orderable` also exists in `wagtail.models`, **DO NOT** use that as the mixins require the model from the same package.
 
 To apply the feature support in admin panel. In `wagtail_hooks.py`:
 ```python
@@ -91,7 +91,7 @@ Note that `sort_order_field` is optional if you extend your model with `Orderabl
 or if your Model has a `sort_order_field` attribute.
 
 Finally, collect the corresponding static file by running
-```python
+```shell
 python manage.py collectstatic
 ```
 in your project.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ INSTALLED_APPS = [
 
 ### Usage
 
-#### Extends with `Orderable` (optionnal)
+#### Extend with `Orderable` (optional)
 
 To apply the orderable feature, you can extend your model with `Orderable` which will add
 a `sort_order` `IntegerField` to your model but if you already have a field to store
@@ -81,14 +81,14 @@ class YourModelAdmin(OrderableMixin, ModelAdmin):
 
 class YourOtherModelAdmin(OrderableMixin, ModelAdmin):
     model = YourOtherModel
-    index_order_field = 'my_custom_order_field'
+    sort_order_field = 'my_custom_order_field'
 
 modeladmin_register(YourModelAdmin)
 modeladmin_register(YourOtherModelAdmin)
 ```
 
-Note that `index_order_field` is optionnal if you extends your model with `Orderable`
-or if your Model has a `index_order_field` attribute.
+Note that `sort_order_field` is optional if you extend your model with `Orderable`
+or if your Model has a `sort_order_field` attribute.
 
 Finally, collect the corresponding static file by running
 ```python

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 from setuptools.command.install import install
 
 INSTALL_REQUIRES = [
-    "wagtail>=2.15,<4.0",
+    "wagtail>=2.15",
 ]
 
 CLASSIFIERS = [

--- a/wagtailorderable/modeladmin/mixins.py
+++ b/wagtailorderable/modeladmin/mixins.py
@@ -1,5 +1,5 @@
 from django.conf.urls import url
-from django.core.exceptions import ImproperlyConfigured, PermissionDenied
+from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured, PermissionDenied
 from django.db import transaction
 from django.db.models import F, Count
 from django.http.response import HttpResponse, HttpResponseBadRequest
@@ -7,30 +7,91 @@ from django.shortcuts import get_object_or_404
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 
-from wagtailorderable.models import Orderable
 
-class OrderableMixin(object):
+class OrderableMixinMetaClass(type):
+    """
+    index_order method needs to be completed with an `admin_order_field` but as sort_order_field
+    is not yet known in the class, we need this meta class to get it from other final class args
+    """
+    def __new__(meta, name, bases, attrs):
+        model = attrs.get('model', None)
+        sort_order_field = attrs.get('sort_order_field', None)
+        if model and not sort_order_field:
+            sort_order_field = getattr(model, 'sort_order_field', None)
+        if sort_order_field:
+            # unfortunately, wagtail IndexView._get_default_ordering is curently using
+            # `model_admin.ordering` instead of `model_admin.get_ordering()`
+            # So we need to automagically set it here
+            if 'ordering' not in attrs:
+                attrs['ordering'] = (sort_order_field, )
+            elif sort_order_field not in attrs['ordering']:
+                attrs['ordering'] = (sort_order_field, ) + tuple(attrs['ordering'])
+
+            # set the "sorting" column
+            if 'index_order' not in attrs:
+                def index_order(self, obj):
+                    """Content for the `index_order` column"""
+                    return mark_safe((
+                        '<div class="handle icon icon-grip text-replace ui-sortable-handle">'
+                        '%s</div>'
+                    ) % _('Drag'))
+                index_order.admin_order_field = sort_order_field
+                index_order.short_description = _('Order')
+                attrs['index_order'] = index_order
+        return type.__new__(meta, name, bases, attrs)
+
+
+class OrderableMixin(object, metaclass=OrderableMixinMetaClass):
+    sort_order_field = None
+
     """
     Mixin class to add drag-and-drop ordering support to the ModelAdmin listing
     view when the model extends the `wagtailorderable.models.Orderable`
     abstract model class.
     """
+
     def __init__(self, parent=None):
         super(OrderableMixin, self).__init__(parent)
         """
         Don't allow initialisation unless self.model subclasses
         `wagtail.models.Orderable`
         """
-        if not issubclass(self.model, Orderable):
+        if not self.sort_order_field and hasattr(self.model, 'sort_order_field'):
+            self.sort_order_field = getattr(self.model, 'sort_order_field', None)
+
+        if not self.sort_order_field:
+            raise ImproperlyConfigured(
+                u"You are using OrderableMixin for your '%(cls)s' class, but the "
+                "django model specified is not a sub-class of "
+                "'wagtail.wagtailcore.models.Orderable and you did not set "
+                "'%(cls)s.sort_order_field'." % {'cls': self.__class__.__name__}
+            )
+        try:
+            self.model._meta.get_field(self.sort_order_field)
+        except FieldDoesNotExist:
             raise ImproperlyConfigured(
                 u"You are using OrderableMixin for your '%s' class, but the "
-                "django model specified is not a sub-class of "
-                "'wagtail.models.Orderable." %
-                self.__class__.__name__,)
+                "'sort_order_field' is set to '%s' which does not exists "
+                "into your model." %
+                (self.__class__.__name__, self.sort_order_field))
+
+    def get_ordering(self, request):
+        """
+        Returns a sequence defining the default ordering for results in the
+        list view.
+        """
+        if not self.ordering:
+            return (self.sort_order_field, )
+        elif self.sort_order_field not in self.ordering:
+            return (self.sort_order_field, ) + tuple(self.ordering)
+        return self.ordering
 
     def get_list_display(self, request):
         """Add `index_order` as the first column to results"""
-        list_display = super().get_list_display(request)
+        list_display = list(super().get_list_display(request))
+        if self.sort_order_field in list_display:
+            # Used JS need one and only one order field displayed in the list
+            list_display.remove(self.sort_order_field)
         return ('index_order', *list_display)
 
     def get_list_display_add_buttons(self, request):
@@ -62,29 +123,22 @@ class OrderableMixin(object):
         return attrs
 
 
-    def get_extra_class_names_for_field_col(self, field_name, obj):
+    def get_extra_class_names_for_field_col(self, obj, field_name):
         """
         Add the `visible-on-drag` class to certain columns
         """
         classnames = super(OrderableMixin, self).get_extra_class_names_for_field_col(
-            field_name, obj)
+            obj, field_name
+        )
         if field_name in ('index_order', self.list_display[0], 'admin_thumb',
                           self.list_display_add_buttons or ''):
             classnames.append('visible-on-drag')
         return classnames
 
-    def index_order(self, obj):
-        """Content for the `index_order` column"""
-        return mark_safe(
-            '<div class="handle icon icon-grip text-replace ui-sortable-handle">Drag</div>'
-        )
-    index_order.admin_order_field = 'sort_order'
-    index_order.short_description = _('Order')
-
     def _get_position(self, pk):
         try:
             obj = self.model.objects.get(pk=pk)
-            return obj.sort_order, obj
+            return getattr(obj, self.sort_order_field), obj
         except self.model.DoesNotExist:
             return None, None
 
@@ -101,7 +155,7 @@ class OrderableMixin(object):
             raise PermissionDenied
 
         # determine the start position
-        old_position = obj_to_move.sort_order or 0
+        old_position = getattr(obj_to_move, self.sort_order_field) or 0
 
         # determine the destination position
         after_position, after = self._get_position(request.GET.get('after'))
@@ -119,35 +173,35 @@ class OrderableMixin(object):
         if position < old_position:
             if position == after_position:
                 position += 1
-            self.model.objects.filter(
-                sort_order__lt=old_position,
-                sort_order__gte=position
-            ).update(sort_order=F('sort_order') + 1)
+            self.model.objects.filter(**{
+                '%s__lt' % self.sort_order_field: old_position,
+                '%s__gte' % self.sort_order_field: position
+            }).update(**{self.sort_order_field:F(self.sort_order_field) + 1})
         elif position > old_position:
             if position == before_position:
                 position -= 1
-            self.model.objects.filter(
-                sort_order__gt=old_position,
-                sort_order__lte=position
-            ).update(sort_order=F('sort_order') - 1)
+            self.model.objects.filter(**{
+                '%s__gt' % self.sort_order_field: old_position,
+                '%s__lte' % self.sort_order_field: position
+            }).update(**{self.sort_order_field: F(self.sort_order_field) - 1})
 
-        obj_to_move.sort_order = position
-        obj_to_move.save(update_fields=['sort_order'])
+        setattr(obj_to_move, self.sort_order_field, position)
+        obj_to_move.save(update_fields=[self.sort_order_field])
         return HttpResponse(response)
 
     @transaction.atomic
     def fix_duplicate_positions(self):
         """
-        Low level function which updates each element to have sequential sort_order values if the database contains any
-        duplicate values (gaps are ok).
+        Low level function which updates each element to have sequential sort_order values
+        if the database contains any duplicate values (gaps are ok).
         """
         duplicates = self.model.objects.values(
-            'sort_order'
-        ).annotate(sort_order_count=Count('sort_order')).filter(sort_order_count__gt=1)
+            self.sort_order_field
+        ).annotate(index_order_count=Count(self.sort_order_field)).filter(index_order_count__gt=1)
 
         if duplicates:
             for n, obj in enumerate(self.model.objects.values('pk')):
-                self.model.objects.filter(pk=obj['pk']).update(sort_order=n)
+                self.model.objects.filter(id=obj['pk']).update(**{self.sort_order_field: n})
 
     def get_index_view_extra_css(self):
         css = super(OrderableMixin, self).get_index_view_extra_css()

--- a/wagtailorderable/modeladmin/mixins.py
+++ b/wagtailorderable/modeladmin/mixins.py
@@ -211,10 +211,10 @@ class OrderableMixin(object, metaclass=OrderableMixinMetaClass):
         if the database contains any duplicate values (gaps are ok).
         """
         qs = self.get_filtered_queryset(request)
-        first_duplicate = qs.values('order')\
+        first_duplicate = qs.values(self.sort_order_field)\
                             .annotate(index_order_count=Count(self.sort_order_field))\
                             .filter(index_order_count__gt=1)\
-                            .order_by('order').first()
+                            .order_by(self.sort_order_field).first()
         if not first_duplicate:
             return
 

--- a/wagtailorderable/modeladmin/mixins.py
+++ b/wagtailorderable/modeladmin/mixins.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import re_path
 from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured, PermissionDenied
 from django.db import connections, transaction
 from django.db.models import F, Count
@@ -7,8 +7,10 @@ from django.db.models.functions import Cast
 from django.http.response import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
-from ..signal import pre_reorder, post_reorder
+from django.utils.translation import gettext_lazy as _
+
+from ..signals import pre_reorder, post_reorder
+
 
 class OrderableMixinMetaClass(type):
     """
@@ -21,7 +23,7 @@ class OrderableMixinMetaClass(type):
         if model and not sort_order_field:
             sort_order_field = getattr(model, 'sort_order_field', None)
         if sort_order_field:
-            # unfortunately, wagtail IndexView._get_default_ordering is curently using
+            # unfortunately, wagtail IndexView._get_default_ordering is currently using
             # `model_admin.ordering` instead of `model_admin.get_ordering()`
             # So we need to automagically set it here
             if 'ordering' not in attrs:
@@ -54,8 +56,10 @@ class OrderableMixin(object, metaclass=OrderableMixinMetaClass):
 
     def __init__(self, parent=None):
         super(OrderableMixin, self).__init__(parent)
-        # Don't allow initialisation unless self.model subclasses
-        # `wagtail.wagtailcore.models.Orderable` or sort_order_field is set
+        """
+        Don't allow initialisation unless self.model subclasses
+        `wagtail.models.Orderable` or sort_order_field is set
+        """
         if not self.sort_order_field and hasattr(self.model, 'sort_order_field'):
             self.sort_order_field = getattr(self.model, 'sort_order_field', None)
 
@@ -63,7 +67,7 @@ class OrderableMixin(object, metaclass=OrderableMixinMetaClass):
             raise ImproperlyConfigured(
                 u"You are using OrderableMixin for your '%(cls)s' class, but the "
                 "django model specified is not a sub-class of "
-                "'wagtail.wagtailcore.models.Orderable and you did not set "
+                "'wagtail.models.Orderable and you did not set "
                 "'%(cls)s.sort_order_field'." % {'cls': self.__class__.__name__}
             )
         try:
@@ -121,7 +125,6 @@ class OrderableMixin(object, metaclass=OrderableMixinMetaClass):
                 'width': 20,
             })
         return attrs
-
 
     def get_extra_class_names_for_field_col(self, obj, field_name):
         """
@@ -276,7 +279,7 @@ class OrderableMixin(object, metaclass=OrderableMixinMetaClass):
     def get_admin_urls_for_registration(self):
         urls = super(OrderableMixin, self).get_admin_urls_for_registration()
         urls += (
-            url(
+            re_path(
                 self.url_helper.get_action_url_pattern('reorder'),
                 view=self.reorder_view,
                 name=self.url_helper.get_action_url_name('reorder')

--- a/wagtailorderable/modeladmin/mixins.py
+++ b/wagtailorderable/modeladmin/mixins.py
@@ -1,19 +1,21 @@
 from django.conf.urls import url
 from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured, PermissionDenied
-from django.db import transaction
+from django.db import connections, transaction
 from django.db.models import F, Count
+from django.db.models.expressions import Case, Value, When
+from django.db.models.functions import Cast
 from django.http.response import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
-
+from ..signal import pre_reorder, post_reorder
 
 class OrderableMixinMetaClass(type):
     """
     index_order method needs to be completed with an `admin_order_field` but as sort_order_field
     is not yet known in the class, we need this meta class to get it from other final class args
     """
-    def __new__(meta, name, bases, attrs):
+    def __new__(cls, name, bases, attrs):
         model = attrs.get('model', None)
         sort_order_field = attrs.get('sort_order_field', None)
         if model and not sort_order_field:
@@ -38,7 +40,7 @@ class OrderableMixinMetaClass(type):
                 index_order.admin_order_field = sort_order_field
                 index_order.short_description = _('Order')
                 attrs['index_order'] = index_order
-        return type.__new__(meta, name, bases, attrs)
+        return type.__new__(cls, name, bases, attrs)
 
 
 class OrderableMixin(object, metaclass=OrderableMixinMetaClass):
@@ -52,10 +54,8 @@ class OrderableMixin(object, metaclass=OrderableMixinMetaClass):
 
     def __init__(self, parent=None):
         super(OrderableMixin, self).__init__(parent)
-        """
-        Don't allow initialisation unless self.model subclasses
-        `wagtail.models.Orderable`
-        """
+        # Don't allow initialisation unless self.model subclasses
+        # `wagtail.wagtailcore.models.Orderable` or sort_order_field is set
         if not self.sort_order_field and hasattr(self.model, 'sort_order_field'):
             self.sort_order_field = getattr(self.model, 'sort_order_field', None)
 
@@ -148,7 +148,7 @@ class OrderableMixin(object, metaclass=OrderableMixinMetaClass):
         Very simple view functionality for updating the `sort_order` values
         for objects after a row has been dragged to a new position.
         """
-        self.fix_duplicate_positions()
+        self.fix_duplicate_positions(request)
 
         obj_to_move = get_object_or_404(self.model, pk=instance_pk)
         if not self.permission_helper.user_can_edit_obj(request.user, obj_to_move):
@@ -162,46 +162,106 @@ class OrderableMixin(object, metaclass=OrderableMixinMetaClass):
         before_position, before = self._get_position(request.GET.get('before'))
         if after:
             position = after_position or 0
-            response = '"%s" moved after "%s"' % (obj_to_move, after)
+            response = _('"%s" moved after "%s"') % (obj_to_move, after)
         elif before:
             position = before_position or 0
-            response = '"%s" moved before "%s"' % (obj_to_move, before)
+            response = _('"%s" moved before "%s"') % (obj_to_move, before)
         else:
-            return HttpResponseBadRequest('"%s" not moved' % obj_to_move)
+            return HttpResponseBadRequest(_('"%s" not moved') % obj_to_move)
 
+        qs = self.get_filtered_queryset(request)
+        signal_kwargs = {'sender': self.__class__, 'queryset': qs}
         # move the object from old_position to new_position
         if position < old_position:
             if position == after_position:
                 position += 1
-            self.model.objects.filter(**{
-                '%s__lt' % self.sort_order_field: old_position,
-                '%s__gte' % self.sort_order_field: position
-            }).update(**{self.sort_order_field:F(self.sort_order_field) + 1})
+            qs = qs.filter(**{'%s__lt' % self.sort_order_field: old_position,
+                              '%s__gte' % self.sort_order_field: position})
+            update_value = F(self.sort_order_field) + 1
+            signal_kwargs.update({'from_order': position, 'to_position': old_position + 1})
         elif position > old_position:
             if position == before_position:
                 position -= 1
-            self.model.objects.filter(**{
-                '%s__gt' % self.sort_order_field: old_position,
-                '%s__lte' % self.sort_order_field: position
-            }).update(**{self.sort_order_field: F(self.sort_order_field) - 1})
+            qs = qs.filter(**{'%s__gt' % self.sort_order_field: old_position,
+                              '%s__lte' % self.sort_order_field: position})
+            update_value = F(self.sort_order_field) - 1
+            signal_kwargs.update({'from_order': old_position - 1, 'to_position': position})
 
-        setattr(obj_to_move, self.sort_order_field, position)
-        obj_to_move.save(update_fields=[self.sort_order_field])
+        # let's signal we will reorder some instances.
+        pre_reorder.send(**signal_kwargs)
+        # reorder all previous|next
+        qs.update(**{self.sort_order_field: update_value})
+        # reorder current one
+        self.model.objects.filter(pk=obj_to_move.pk)\
+                          .update(**{self.sort_order_field: position})
+        # let's signal we just reorder some instances.
+        post_reorder.send(**signal_kwargs)
         return HttpResponse(response)
 
+    def get_filtered_queryset(self, request):
+        parent_field = getattr(self, 'parent_field', None)
+        if not parent_field or parent_field not in request.GET:
+            return self.get_queryset(request)
+        return self.get_queryset(request).filter(**{parent_field: request.GET.get(parent_field)})
+
     @transaction.atomic
-    def fix_duplicate_positions(self):
+    def fix_duplicate_positions(self, request):
         """
         Low level function which updates each element to have sequential sort_order values
         if the database contains any duplicate values (gaps are ok).
         """
-        duplicates = self.model.objects.values(
-            self.sort_order_field
-        ).annotate(index_order_count=Count(self.sort_order_field)).filter(index_order_count__gt=1)
+        qs = self.get_filtered_queryset(request)
+        first_duplicate = qs.values('order')\
+                            .annotate(index_order_count=Count(self.sort_order_field))\
+                            .filter(index_order_count__gt=1)\
+                            .order_by('order').first()
+        if not first_duplicate:
+            return
 
-        if duplicates:
-            for n, obj in enumerate(self.model.objects.values('pk')):
-                self.model.objects.filter(id=obj['pk']).update(**{self.sort_order_field: n})
+        # let's retrieve all next the first duplicate found
+        lookups = {'%s__gte' % self.sort_order_field: first_duplicate[self.sort_order_field]}
+        to_reorder = qs.filter(**lookups).order_by(self.sort_order_field)\
+                       .values_list('pk', self.sort_order_field)[1:]
+                       # first one has the good order value, so we don't get it
+
+        # let's prepare our custom bulk_update to reorder the wring ordered ones
+        # (we don't use django's native bulk_update which require real model instances which is
+        # overkill in our case). When django's bulk_update will be able to accept iterable of dicts
+        # we won't need this custom bulk_update anymore.
+        field = self.model._meta.get_field(self.sort_order_field)
+        when_statements = []
+        pks = []
+        bulk_update_qs = self.get_filtered_queryset(request)
+        new_order = first_duplicate['index_order_count']
+        for pk, current_order in to_reorder:
+            new_order += 1
+            if current_order > new_order:
+                # we are ok with gaps, this one does not need to be updated
+                new_order = current_order + 1
+                continue
+            if current_order == new_order:
+                # neither this one
+                continue
+            pks.append(pk)
+            when_statements.append(When(pk=pk, then=Value(new_order, output_field=field)))
+        case_statement = Case(*when_statements, output_field=field)
+        if connections[bulk_update_qs.db].features.requires_casted_case_in_updates:
+            case_statement = Cast(case_statement, output_field=field)
+        # let's signal we will reorder some instances.
+        pre_reorder.send(
+            sender=self.__class__,
+            from_order=first_duplicate['index_order_count'] + 1,
+            to_order=new_order,
+            queryset=bulk_update_qs,
+        )
+        bulk_update_qs.filter(pk__in=pks).update(**{self.sort_order_field: case_statement})
+        # let's signal we just reorder some instances.
+        post_reorder.send(
+            sender=self.__class__,
+            from_order=first_duplicate['index_order_count'] + 1,
+            to_order=new_order,
+            queryset=bulk_update_qs,
+        )
 
     def get_index_view_extra_css(self):
         css = super(OrderableMixin, self).get_index_view_extra_css()

--- a/wagtailorderable/signal.py
+++ b/wagtailorderable/signal.py
@@ -1,0 +1,11 @@
+from django.dispatch import Signal
+
+# queryset is the whole "base queryset": it does not filter only on those updated
+# but filters on a parent key for exemple. eg. Book -> Chapter: Chapters need to be ordered
+# by book, and their ordering is important (can not be shared between all books)
+# in that case, you should use a "child model admin" which will allow you to display (and reorder)
+# only chapters for a specific books. The queryset sends to signals is filtered with the
+# "current book".
+
+pre_reorder = Signal(providing_args=['from_order', 'to_order', 'queryset'])
+post_reorder = Signal(providing_args=['from_order', 'to_order', 'queryset'])

--- a/wagtailorderable/signals.py
+++ b/wagtailorderable/signals.py
@@ -1,11 +1,14 @@
 from django.dispatch import Signal
 
 # queryset is the whole "base queryset": it does not filter only on those updated
-# but filters on a parent key for exemple. eg. Book -> Chapter: Chapters need to be ordered
+# but filters on a parent key for example. eg. Book -> Chapter: Chapters need to be ordered
 # by book, and their ordering is important (can not be shared between all books)
 # in that case, you should use a "child model admin" which will allow you to display (and reorder)
 # only chapters for a specific books. The queryset sends to signals is filtered with the
 # "current book".
 
-pre_reorder = Signal(providing_args=['from_order', 'to_order', 'queryset'])
-post_reorder = Signal(providing_args=['from_order', 'to_order', 'queryset'])
+# provides args: from_order, to_order, queryset
+pre_reorder = Signal()
+
+# provides args: from_order, to_order, queryset
+post_reorder = Signal()

--- a/wagtailorderable/static/wagtailorderable/modeladmin/css/orderablemixin.css
+++ b/wagtailorderable/static/wagtailorderable/modeladmin/css/orderablemixin.css
@@ -1,19 +1,16 @@
-.result-list {
-    tbody {
-        overflow: auto;
-    }
+.result-list tbody {
+    overflow: auto;
+}
 
-    tr > td {
-        background-color: inherit;
-    }
+.result-list tr > td {
+    background-color: inherit;
+}
 
-    tr.ui-sortable-helper {
-        background-color: #fff;
-
-        .visible-on-drag {
-            display: table-cell;
-        }
-    }
+.result-list tr.ui-sortable-helper {
+    background-color: #fff;
+}
+.result-list tr.ui-sortable-helper .visible-on-drag {
+    display: table-cell;
 }
 
 td.field-index_order > div.icon {

--- a/wagtailorderable/static/wagtailorderable/modeladmin/js/orderablemixin.js
+++ b/wagtailorderable/static/wagtailorderable/modeladmin/js/orderablemixin.js
@@ -5,7 +5,6 @@ $(function() {
     var sorted_cols = listing_thead.find('th.sorted');
     order_header.find('a').addClass('text-replace').removeClass('icon icon-arrow-down-after icon-arrow-up-after')
     order_header.find('a').html('<span class="icon icon-order" aria-hidden="true"></span> Sort');
-
     if(sorted_cols.length == 1 && order_header.hasClass('sorted') && order_header.hasClass('ascending')){
         order_header.find('a').attr('title', 'Restore default list ordering').attr('href', '?');
         listing_tbody.sortable({
@@ -60,7 +59,11 @@ $(function() {
         listing_tbody.disableSelection();
     } else {
         $('.field-index_order .handle').remove();
-        order_header.find('a').attr('title', 'Enable ordering of objects').attr('href', '?o=0');
-        order_header.removeClass('sorted ascending')
+        var a = order_header.find('a');
+        a.attr('title', 'Enable ordering of objects');
+        var href = new URL(window.location.href);  // we need to keep current filters
+        href.searchParams.set('o', '0');
+        a.attr('href', href.toString());
+        order_header.removeClass('sorted ascending');
     }
 });

--- a/wagtailorderable/static/wagtailorderable/modeladmin/js/orderablemixin.js
+++ b/wagtailorderable/static/wagtailorderable/modeladmin/js/orderablemixin.js
@@ -3,7 +3,7 @@ $(function() {
     var listing_tbody = $('.listing tbody');
     var listing_thead = $('.listing thead');
     var sorted_cols = listing_thead.find('th.sorted');
-    order_header.find('a').addClass('text-replace').removeClass('icon icon-arrow-down-after icon-arrow-up-after')
+    order_header.find('a').addClass('text-replace').removeClass('icon icon-arrow-down-after icon-arrow-up-after');
     order_header.find('a').html('<span class="icon icon-order" aria-hidden="true"></span> Sort');
     if(sorted_cols.length == 1 && order_header.hasClass('sorted') && order_header.hasClass('ascending')){
         order_header.find('a').attr('title', 'Restore default list ordering').attr('href', '?');
@@ -27,24 +27,26 @@ $(function() {
                 var movedObjectId = movedElement.data('object-pk');
                 var movedObjectTitle = movedElement.find('td.field-index_order').data('title');
 
-                // Build params
-                var params;
+                // Build params keeping current filters if this view is a child modeladmin
+                // eg: Books -> Chapters: we need to keep the current selected book
+                var params = new URL(window.location.href).searchParams;
+                var idx;
                 if ($(this).data('idx') < ui.item.index()) {
-                    var after = $(movedElement).prev().data('object-pk');
-                    if (after) {
-                        params= "?after=" + after;
+                    idx = $(movedElement).prev().data('object-pk');
+                    if (idx) {
+                        params.set('after', idx);
                     }
                 } else if ($(this).data('idx') > ui.item.index()) {
-                    var before = $(movedElement).next().data('object-pk');
-                    if (before) {
-                        params = "?before=" + before;
+                    idx = $(movedElement).next().data('object-pk');
+                    if (idx) {
+                        params.set('before', idx);
                     }
                 }
 
                 // Post
-                if (params) {
+                if (idx) {
                     $.ajax({
-                        url: 'reorder/' + movedObjectId + '/' + params,
+                        url: 'reorder/' + movedObjectId + '/?' + params.toString(),
                         success: function(data, textStatus, xhr) {
                             addMessage('success', '"' + movedObjectTitle + '" has been moved successfully.');
                         },


### PR DESCRIPTION
This is the updated version of #27.

I've applied all suggestions found by https://github.com/elton2048/wagtail-orderable/pull/27#issuecomment-1159483910, but also found some other improvements.

I've tested it with 3 setups:
* wagtail 3.0.1 / django 4.0.5 using the [bakerydemo](https://github.com/wagtail/bakerydemo)
* wagtail 3.0.1 / django 3.2.13
* wagtail 2.15.5 / django 3.2.13