### PR TITLE
Update dependencies for Wagtail 4.2

### DIFF
--- a/.github/workflows/publish-package-actions.yml
+++ b/.github/workflows/publish-package-actions.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ in your project.
 
 ### Change Log
 
+Unreleased
+---
+- Updated documentation for wagtail 4.0 support
+- Updated workflow action versions
+
 1.1.0
 ---
 - Extending `Orderable` is no more mandatory if you want to use your own order field (#27)

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Unreleased
 ---
 - Updated documentation for wagtail 4.0 support
 - Updated workflow action versions
+- Allow wagtail v4.1+ (drops ability to use on a wagtail site version earlier than v4.1)
 
 1.1.0
 ---

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 from setuptools.command.install import install
 
 INSTALL_REQUIRES = [
-    "wagtail>=2.15",
+    "wagtail>=4.1",
 ]
 
 CLASSIFIERS = [
@@ -26,9 +26,8 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Framework :: Wagtail",
-    "Framework :: Wagtail :: 2",
-    "Framework :: Wagtail :: 3",
     "Framework :: Wagtail :: 4",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ CLASSIFIERS = [
     "Framework :: Django",
     "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.0",
+    "Framework :: Django :: 4.1",
     'License :: OSI Approved :: zlib/libpng License',
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.7",
@@ -28,6 +29,7 @@ CLASSIFIERS = [
     "Framework :: Wagtail",
     "Framework :: Wagtail :: 2",
     "Framework :: Wagtail :: 3",
+    "Framework :: Wagtail :: 4",
 ]
 
 class VerifyVersionCommand(install):


### PR DESCRIPTION
This updates the package dependencies to support Wagtail 4.1 +

We are generally working towards only supporting the latest Wagtail version (4.2) plus one LTS version backwards. Please let me know if this isn't compatible with your plan for supported versions. Thanks