### PR TITLE
Support for wagtail v5 and Django v4.2

### DIFF
--- a/.github/workflows/publish-package-actions.yml
+++ b/.github/workflows/publish-package-actions.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ local_settings.py
 
 .env
 db.sqlite3
+.venv

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Unreleased
 - Updated documentation for wagtail 4.0 support
 - Updated workflow action versions
 - Allow wagtail v4.1+ (drops ability to use on a wagtail site version earlier than v4.1)
+- Allow Wagtail v5 and Django v4.2
 
 1.1.0
 ---

--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ in your project.
 
 ### Change Log
 
+Unreleased
+---
+- Updated documentation for wagtail 4.0 support
+- Updated workflow action versions
+
 1.1.0
 ---
 - Extending `Orderable` is no more mandatory if you want to use your own order field (#27)

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Unreleased
 ---
 - Updated documentation for wagtail 4.0 support
 - Updated workflow action versions
+- Allow wagtail v4.1+ (drops ability to use on a wagtail site version earlier than v4.1)
 
 1.1.0
 ---

--- a/setup.py
+++ b/setup.py
@@ -18,17 +18,17 @@ CLASSIFIERS = [
     'Programming Language :: Python',
     "Framework :: Django",
     "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4.0",
     "Framework :: Django :: 4.1",
+    "Framework :: Django :: 4.2",
     'License :: OSI Approved :: zlib/libpng License',
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Framework :: Wagtail",
     "Framework :: Wagtail :: 4",
+    "Framework :: Wagtail :: 5",
 ]
 
 class VerifyVersionCommand(install):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 from setuptools.command.install import install
 
 INSTALL_REQUIRES = [
-    "wagtail>=2.15",
+    "wagtail>=4.1",
 ]
 
 CLASSIFIERS = [
@@ -26,9 +26,8 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Framework :: Wagtail",
-    "Framework :: Wagtail :: 2",
-    "Framework :: Wagtail :: 3",
     "Framework :: Wagtail :: 4",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ CLASSIFIERS = [
     "Framework :: Django",
     "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.0",
+    "Framework :: Django :: 4.1",
     'License :: OSI Approved :: zlib/libpng License',
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.7",
@@ -28,6 +29,7 @@ CLASSIFIERS = [
     "Framework :: Wagtail",
     "Framework :: Wagtail :: 2",
     "Framework :: Wagtail :: 3",
+    "Framework :: Wagtail :: 4",
 ]
 
 class VerifyVersionCommand(install):


### PR DESCRIPTION
There are no code changes required to support Wagtail v5

This just updates the classifiers in setup.py

I tested it on a fresh Wagtail v5 site and it works perfect.

Includes: https://github.com/elton2048/wagtail-orderable/pull/41