### PR TITLE
Wagtail 6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,14 @@ Simple orderable mixin to add drag-and-drop ordering support to the `ModelAdmin`
 
 It attempts to provide the [feature request](https://github.com/wagtail/wagtail/issues/2941) in Wagtail project without modifying the project code as it seems not a high priority item for the project.
 
+From Wagtail >= 5.2, ModelAdmin has been moved to a separate package. If you are using Wagtail 5.2 or later, you need to install `wagtail-modeladmin` separately from https://github.com/wagtail-nest/wagtail-modeladmin.
+
 ### Installation
 
 Install the package
 ```
 pip install wagtail-orderable
+pip install wagtail-modeladmin
 ```
 
 ### Settings
@@ -17,6 +20,7 @@ In your settings file, add `wagtailorderable` to `INSTALLED_APPS`:
 INSTALLED_APPS = [
     # ...
     'wagtailorderable',
+    'wagtail_modeladmin',
     # ...
 ]
 ```
@@ -67,7 +71,7 @@ Note that `Orderable` also exists in `wagtail.models`, **DO NOT** use that as th
 
 To apply the feature support in admin panel. In `wagtail_hooks.py`:
 ```python
-from wagtail.contrib.modeladmin.options import (
+from wagtail_modeladmin.options import (
     ModelAdmin, modeladmin_register)
 
 from wagtailorderable.modeladmin.mixins import OrderableMixin

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ from setuptools import setup, find_packages
 from setuptools.command.install import install
 
 INSTALL_REQUIRES = [
-    "wagtail>=4.1",
+    "wagtail>=5.2",
+    "wagtail-modeladmin>=2.0.0",
 ]
 
 CLASSIFIERS = [
@@ -18,7 +19,6 @@ CLASSIFIERS = [
     'Programming Language :: Python',
     "Framework :: Django",
     "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
     'License :: OSI Approved :: zlib/libpng License',
     "Programming Language :: Python :: 3",
@@ -26,9 +26,12 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Framework :: Wagtail",
     "Framework :: Wagtail :: 4",
     "Framework :: Wagtail :: 5",
+    "Framework :: Wagtail :: 6",
+
 ]
 
 class VerifyVersionCommand(install):

--- a/wagtailorderable/modeladmin/mixins.py
+++ b/wagtailorderable/modeladmin/mixins.py
@@ -6,7 +6,7 @@ from django.db.models.expressions import Case, Value, When
 from django.db.models.functions import Cast
 from django.http.response import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404
-from django.utils.safestring import mark_safe
+from django.template.loader import get_template
 from django.utils.translation import gettext_lazy as _
 
 from ..signals import pre_reorder, post_reorder
@@ -35,10 +35,8 @@ class OrderableMixinMetaClass(type):
             if 'index_order' not in attrs:
                 def index_order(self, obj):
                     """Content for the `index_order` column"""
-                    return mark_safe((
-                        '<div class="handle icon icon-grip text-replace ui-sortable-handle">'
-                        '%s</div>'
-                    ) % _('Drag'))
+                    template = get_template('wagtailorderable/index_order.html')
+                    return template.render()
                 index_order.admin_order_field = sort_order_field
                 index_order.short_description = _('Order')
                 attrs['index_order'] = index_order

--- a/wagtailorderable/static/wagtailorderable/modeladmin/css/orderablemixin.css
+++ b/wagtailorderable/static/wagtailorderable/modeladmin/css/orderablemixin.css
@@ -14,5 +14,5 @@
 }
 
 td.field-index_order > div.icon {
-    margin-left: 13px;
+    padding: .25em;
 }

--- a/wagtailorderable/static/wagtailorderable/modeladmin/js/orderablemixin.js
+++ b/wagtailorderable/static/wagtailorderable/modeladmin/js/orderablemixin.js
@@ -48,10 +48,14 @@ $(function() {
                     $.ajax({
                         url: 'reorder/' + movedObjectId + '/?' + params.toString(),
                         success: function(data, textStatus, xhr) {
-                            addMessage('success', '"' + movedObjectTitle + '" has been moved successfully.');
+                            const text = '"' + movedObjectTitle + '" has been moved successfully.';
+                            const event = new CustomEvent('w-messages:add', { detail: { clear: true, text,  type: 'success' } });
+                            document.dispatchEvent(event);
                         },
                         error: function(data, textStatus, xhr) {
-                            addMessage('error', '"' + movedObjectTitle + '" could not be moved.');
+                            const text = '"' + movedObjectTitle + '" could not be moved.';
+                            const event = new CustomEvent('w-messages:add', { detail: { clear: true, text,  type: 'error' } });
+                            document.dispatchEvent(event);
                             listing_tbody.sortable("cancel");
                         }
                     });

--- a/wagtailorderable/templates/wagtailorderable/index_order.html
+++ b/wagtailorderable/templates/wagtailorderable/index_order.html
@@ -1,0 +1,12 @@
+{% load i18n wagtailadmin_tags %}
+
+
+<div class="handle icon icon-grip ui-sortable-handle">
+    {% icon name="grip" classname="default" %}
+    <span class="w-sr-only">
+        {% trans 'Drag' %}
+        <span>
+            {% blocktranslate trimmed with index=row.index|add:1 total=table.row_count %}Item {{ index }} of {{ total }}{% endblocktranslate %}
+        </span>
+    </span>
+</div>


### PR DESCRIPTION
The deprecated SVG icon font has been removed from Wagtail core, this includes the grip icon. This needed to be updated to use the new icon.